### PR TITLE
Push docker images to gacwr org and fix build badge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,10 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build frontend Docker image
-        run: docker build -f docker/frontend.dockerfile -t ${{ secrets.DOCKER_USERNAME }}/openuba-frontend:latest .
+        run: docker build -f docker/frontend.dockerfile -t gacwr/openuba-frontend:latest .
 
       - name: Push frontend Docker image
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/openuba-frontend:latest
+        run: docker push gacwr/openuba-frontend:latest
 
   build-backend:
     name: Build and push backend
@@ -34,7 +34,7 @@ jobs:
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build backend Docker image
-        run: docker build -f docker/backend.dockerfile -t ${{ secrets.DOCKER_USERNAME }}/openuba-backend:latest .
+        run: docker build -f docker/backend.dockerfile -t gacwr/openuba-backend:latest .
 
       - name: Push backend Docker image
-        run: docker push ${{ secrets.DOCKER_USERNAME }}/openuba-backend:latest
+        run: docker push gacwr/openuba-backend:latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A robust, flexible, and lightweight open source User & Entity Behavior Analytics
 
 | Status | Badge | Status | Badge |
 | --- | --- | --- | --- |
-| `Build` | [![Build](https://img.shields.io/github/actions/workflow/status/GACWR/OpenUBA/ci.yml?branch=master&label=build)](https://github.com/GACWR/OpenUBA/actions) | `License` | [![License](https://img.shields.io/badge/license-GPL-blue.svg)](https://github.com/GACWR/OpenUBA/blob/master/LICENSE) |
+| `Build` | [![Build](https://img.shields.io/github/actions/workflow/status/GACWR/OpenUBA/docker-publish.yml?branch=master&label=build)](https://github.com/GACWR/OpenUBA/actions) | `License` | [![License](https://img.shields.io/badge/license-GPL-blue.svg)](https://github.com/GACWR/OpenUBA/blob/master/LICENSE) |
 | `Issues` | [![Issues](https://img.shields.io/github/issues/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA/issues) | `Closed Issues` | [![Closed Issues](https://img.shields.io/github/issues-closed/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA/issues?q=is%3Aissue+is%3Aclosed) |
 | `Pull Requests` | [![PRs](https://img.shields.io/github/issues-pr/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA/pulls) | `Last Commit` | [![Last commit](https://img.shields.io/github/last-commit/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA/commits/master) |
 | `Top Language` | [![Top language](https://img.shields.io/github/languages/top/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA) | `Code Size` | [![Code size](https://img.shields.io/github/languages/code-size/GACWR/OpenUBA.svg)](https://github.com/GACWR/OpenUBA) |


### PR DESCRIPTION
Update docker-publish workflow to push images to gacwr/ namespace instead of personal account. Fix README build badge to point at docker-publish.yml workflow.