### PR TITLE
fix(api): default Hub server URL → live https://openuba.org

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -82,7 +82,7 @@ class LibraryAPI():
         logging.info("Library API")
 
         # optional: point to a custom repo
-        self.server: str = "http://openuba.gacwr.org"
+        self.server: str = "https://openuba.org"
 
 
     def install(self, model_name: str):


### PR DESCRIPTION
Surfaced by the 3-agent ROADMAP audit on PR #137 (Agent A + C audits at `.cncf-roadmap-audit/audit-{A,C}-*.md`).

**The find:** `core/api.py:85` still defaulted to `http://openuba.gacwr.org` — a dead host. The actual live public Hub instance is `https://openuba.org` (HTTP 200, sibling repo `openuba-model-hub` deploys it with `CNAME=openuba.org`). The newer `core/registry/adapters/openuba_hub_adapter.py` was already pointing at the live URL; this brings the legacy API surface in line.

**Change:** 1 line. `http://openuba.gacwr.org` → `https://openuba.org` in `core/api.py:85`.

cc @jovonni — landed off fresh master post-#137 and #138 merges. cc @copilot — straightforward URL fix.