### PR TITLE
fix(api): non-blocking asyncio.sleep in lifespan db-retry backoff (#140)

### DIFF
--- a/core/fastapi_app.py
+++ b/core/fastapi_app.py
@@ -3,6 +3,7 @@ Copyright 2019-Present The OpenUBA Platform Authors
 fastapi application entry point
 '''
 
+import asyncio
 import logging
 import os
 from fastapi import FastAPI
@@ -155,8 +156,7 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             if attempt < max_retries - 1:
                 logger.warning(f"database initialization failed (attempt {attempt + 1}/{max_retries}): {e}, retrying in {retry_delay}s...")
-                import time
-                time.sleep(retry_delay)
+                await asyncio.sleep(retry_delay)
             else:
                 logger.error(f"database initialization failed after {max_retries} attempts: {e}")
     

--- a/core/tests/test_lifespan_async.py
+++ b/core/tests/test_lifespan_async.py
@@ -1,0 +1,52 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+lifespan async-safety tests (regression for #140)
+
+verifies the fastapi lifespan uses a non-blocking backoff
+(await asyncio.sleep) instead of a blocking time.sleep that
+would stall the event loop during db reconnection attempts.
+'''
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core import fastapi_app
+
+
+def test_lifespan_source_has_no_blocking_sleep():
+    '''
+    static guard: the lifespan retry loop must not call time.sleep,
+    and must await asyncio.sleep for its backoff
+    '''
+    source = inspect.getsource(fastapi_app.lifespan)
+    assert "time.sleep" not in source, "lifespan must not block the event loop with time.sleep"
+    assert "await asyncio.sleep" in source, "lifespan backoff must use await asyncio.sleep"
+
+
+@pytest.mark.asyncio
+async def test_lifespan_retries_with_non_blocking_sleep(monkeypatch):
+    '''
+    functional guard: when init_db fails once then succeeds, the lifespan
+    retries and backs off via a non-blocking await asyncio.sleep call
+    '''
+    # kubernetes mode skips local ingestion + local postgraphile bootstrap
+    monkeypatch.setenv("EXECUTION_MODE", "kubernetes")
+    monkeypatch.setenv("ENABLE_GRAPHQL", "false")
+
+    init_db_mock = MagicMock(side_effect=[RuntimeError("db not ready"), None])
+    sleep_mock = AsyncMock()
+
+    with patch.object(fastapi_app, "init_db", init_db_mock), \
+         patch.object(fastapi_app, "seed_defaults", MagicMock()), \
+         patch.object(fastapi_app, "ModelInstaller", MagicMock()), \
+         patch.object(fastapi_app, "ModelScheduler", MagicMock()), \
+         patch.object(fastapi_app.asyncio, "sleep", sleep_mock):
+        async with fastapi_app.lifespan(fastapi_app.app):
+            pass
+
+    # init_db was retried (failed once, then succeeded)
+    assert init_db_mock.call_count == 2
+    # backoff happened exactly once, via the non-blocking await path
+    sleep_mock.assert_awaited_once_with(5)


### PR DESCRIPTION
## What

The FastAPI startup `lifespan` retried `init_db()` with a blocking `time.sleep(retry_delay)` inside an `async def`. That blocks the event loop for the full backoff window on every failed attempt, so anything sharing the loop from the first instant (health/readiness probes) can be delayed while the DB is reconnecting.

Swaps it for `await asyncio.sleep(retry_delay)` (non-blocking), and adds `import asyncio` at module top.

## Why

Flagged in #140 — small, correct one-liner with a real (if narrow) impact on startup responsiveness.

## Tests

New regression subsuite `core/tests/test_lifespan_async.py`:
- static guard — the lifespan source contains no `time.sleep` and uses `await asyncio.sleep`
- functional — `init_db()` fails once then succeeds; asserts the retry path awaits the non-blocking sleep exactly once (event loop never blocks)

Runs under the existing `core/tests/` pytest suite in CI.

Closes #140