### PR TITLE
feat(integrations): Splunk data source + anomaly forwarding (#99)

### DIFF
--- a/core/api_routers/models.py
+++ b/core/api_routers/models.py
@@ -26,6 +26,8 @@ class TrainRequest(BaseModel):
     file_path: Optional[str] = None
     file_name: Optional[str] = None
     source_group_slug: Optional[str] = None
+    splunk_search: Optional[str] = None
+    splunk_index: Optional[str] = None
     query: Optional[Dict[str, Any]] = None
     version_id: Optional[str] = None
 
@@ -37,6 +39,8 @@ class ExecuteRequest(BaseModel):
     file_path: Optional[str] = None
     file_name: Optional[str] = None
     source_group_slug: Optional[str] = None
+    splunk_search: Optional[str] = None
+    splunk_index: Optional[str] = None
     query: Optional[Dict[str, Any]] = None
     version_id: Optional[str] = None
     artifact_id: Optional[str] = None
@@ -311,6 +315,8 @@ async def train_model(
     file_path: Optional[str] = Query(None, description="local file path"),
     file_name: Optional[str] = Query(None, description="local file name"),
     source_group_slug: Optional[str] = Query(None, description="source group slug"),
+    splunk_search: Optional[str] = Query(None, description="splunk search query (SPL)"),
+    splunk_index: Optional[str] = Query(None, description="splunk index to search"),
     db: Session = Depends(get_db),
     current_user: dict = Depends(require_permission("models", "write"))
 ):
@@ -328,6 +334,8 @@ async def train_model(
     _file_path = (body.file_path if body else None) or file_path
     _file_name = (body.file_name if body else None) or file_name
     _source_group_slug = (body.source_group_slug if body else None) or source_group_slug
+    _splunk_search = (body.splunk_search if body else None) or splunk_search
+    _splunk_index = (body.splunk_index if body else None) or splunk_index
     _query = (body.query if body else None) or {"match_all": {}}
     _version_id = None
     if body and body.version_id:
@@ -362,6 +370,10 @@ async def train_model(
             input_data["file_name"] = _file_name
         elif _data_source == "source_group" and _source_group_slug:
             input_data["source_group_slug"] = _source_group_slug
+        elif _data_source == "splunk" and _splunk_search:
+            input_data["splunk_search"] = _splunk_search
+            if _splunk_index:
+                input_data["splunk_index"] = _splunk_index
 
     try:
         orchestrator = ModelOrchestrator()
@@ -410,6 +422,8 @@ async def execute_model(
     file_path: Optional[str] = Query(None, description="local file path"),
     file_name: Optional[str] = Query(None, description="local file name"),
     source_group_slug: Optional[str] = Query(None, description="source group slug"),
+    splunk_search: Optional[str] = Query(None, description="splunk search query (SPL)"),
+    splunk_index: Optional[str] = Query(None, description="splunk index to search"),
     db: Session = Depends(get_db),
     current_user: dict = Depends(require_permission("models", "write"))
 ):
@@ -427,6 +441,8 @@ async def execute_model(
     _file_path = (body.file_path if body else None) or file_path
     _file_name = (body.file_name if body else None) or file_name
     _source_group_slug = (body.source_group_slug if body else None) or source_group_slug
+    _splunk_search = (body.splunk_search if body else None) or splunk_search
+    _splunk_index = (body.splunk_index if body else None) or splunk_index
     _query = (body.query if body else None) or {"match_all": {}}
     _version_id = None
     if body and body.version_id:
@@ -466,6 +482,10 @@ async def execute_model(
             input_data["file_name"] = _file_name
         elif _data_source == "source_group" and _source_group_slug:
             input_data["source_group_slug"] = _source_group_slug
+        elif _data_source == "splunk" and _splunk_search:
+            input_data["splunk_search"] = _splunk_search
+            if _splunk_index:
+                input_data["splunk_index"] = _splunk_index
 
     try:
         orchestrator = ModelOrchestrator()

--- a/core/api_routers/settings.py
+++ b/core/api_routers/settings.py
@@ -17,7 +17,7 @@ from core.auth import require_permission
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-VALID_INTEGRATION_TYPES = {"ollama", "openai", "claude", "gemini", "elasticsearch", "spark"}
+VALID_INTEGRATION_TYPES = {"ollama", "openai", "claude", "gemini", "elasticsearch", "spark", "splunk"}
 
 
 class IntegrationConfigUpdate(BaseModel):
@@ -183,6 +183,8 @@ async def test_integration(
             return await _test_elasticsearch(config)
         elif integration_type == "spark":
             return await _test_spark(config)
+        elif integration_type == "splunk":
+            return await _test_splunk(config)
     except Exception as e:
         logger.error(f"test {integration_type} failed: {e}")
         return {"status": "error", "message": str(e)}
@@ -283,10 +285,16 @@ async def _test_spark(config: dict) -> dict:
         return {"status": "error", "message": f"HTTP {resp.status_code}"}
 
 
+async def _test_splunk(config: dict) -> dict:
+    '''verify Splunk connectivity via the shared SplunkConnector'''
+    from core.integrations.splunk import SplunkConnector
+    return SplunkConnector.from_config(config).test_connection()
+
+
 def _mask_sensitive_fields(config: dict) -> dict:
-    '''mask api keys in config for safe display'''
+    '''mask api keys / tokens / passwords in config for safe display'''
     masked = dict(config)
-    for key in ("api_key",):
+    for key in ("api_key", "token", "hec_token", "password"):
         if key in masked and masked[key]:
             val = str(masked[key])
             if len(val) > 8:

--- a/core/integrations/__init__.py
+++ b/core/integrations/__init__.py
@@ -5,9 +5,11 @@ integrations package
 
 from core.integrations.spark import SparkConnector
 from core.integrations.elasticsearch import ElasticsearchConnector
+from core.integrations.splunk import SplunkConnector
 
 __all__ = [
     "SparkConnector",
     "ElasticsearchConnector",
+    "SplunkConnector",
 ]
 

--- a/core/integrations/splunk.py
+++ b/core/integrations/splunk.py
@@ -1,0 +1,244 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+splunk integration
+
+Two directions:
+  * INPUT  — run a Splunk search and return events (via the REST export API)
+  * OUTPUT — forward anomalies/events to Splunk (via the HTTP Event Collector)
+
+Config comes from constructor args with SPLUNK_* env fallbacks, matching the
+ElasticsearchConnector pattern. Nothing here is Splunk-SDK-dependent — it uses
+plain `requests`, so it also works unchanged inside the self-contained model
+runner container.
+'''
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+class SplunkConnector:
+    '''
+    connector for Splunk Enterprise / Cloud.
+
+    host      — management REST endpoint, e.g. https://splunk:8089 (for search)
+    token     — bearer token for the REST API (preferred), OR
+    username/password — basic auth for the REST API
+    hec_url   — HTTP Event Collector base, e.g. https://splunk:8088 (for output)
+    hec_token — HEC token
+    '''
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        token: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        hec_url: Optional[str] = None,
+        hec_token: Optional[str] = None,
+        verify_ssl: Optional[bool] = None,
+        timeout: int = 60,
+    ):
+        self.host = (host or os.getenv("SPLUNK_HOST", "")).rstrip("/")
+        self.token = token or os.getenv("SPLUNK_TOKEN", "")
+        self.username = username or os.getenv("SPLUNK_USERNAME", "")
+        self.password = password or os.getenv("SPLUNK_PASSWORD", "")
+        self.hec_url = (hec_url or os.getenv("SPLUNK_HEC_URL", "")).rstrip("/")
+        self.hec_token = hec_token or os.getenv("SPLUNK_HEC_TOKEN", "")
+        if verify_ssl is None:
+            verify_ssl = _env_flag("SPLUNK_VERIFY_SSL", True)
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "SplunkConnector":
+        '''build a connector from an integration_settings config dict'''
+        return cls(
+            host=config.get("host"),
+            token=config.get("token"),
+            username=config.get("username"),
+            password=config.get("password"),
+            hec_url=config.get("hec_url"),
+            hec_token=config.get("hec_token"),
+            verify_ssl=config.get("verify_ssl", True),
+        )
+
+    # ── auth ─────────────────────────────────────────────────────────
+
+    def _rest_headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _rest_auth(self):
+        '''basic auth tuple when no bearer token is configured'''
+        if not self.token and self.username:
+            return (self.username, self.password)
+        return None
+
+    # ── INPUT: search ────────────────────────────────────────────────
+
+    @staticmethod
+    def _normalize_query(query: str) -> str:
+        '''Splunk searches must start with `search` or a generating command (`|`)'''
+        q = (query or "").strip()
+        if not q:
+            raise ValueError("splunk search query is empty")
+        if q.startswith("|") or q.lower().startswith("search "):
+            return q
+        return f"search {q}"
+
+    def search(
+        self,
+        query: str,
+        earliest_time: str = "-24h",
+        latest_time: str = "now",
+        max_count: int = 1000,
+    ) -> List[Dict[str, Any]]:
+        '''
+        run a blocking Splunk search via the export endpoint and return the
+        list of result rows (each a flat dict of field → value).
+        '''
+        if not self.host:
+            raise ValueError("splunk host not configured")
+
+        url = f"{self.host}/services/search/jobs/export"
+        payload = {
+            "search": self._normalize_query(query),
+            "output_mode": "json",
+            "earliest_time": earliest_time,
+            "latest_time": latest_time,
+            "count": max_count,
+        }
+        logger.info(f"running splunk search on {self.host} (count<={max_count})")
+        resp = requests.post(
+            url,
+            data=payload,
+            headers=self._rest_headers(),
+            auth=self._rest_auth(),
+            verify=self.verify_ssl,
+            timeout=self.timeout,
+        )
+        if resp.status_code != 200:
+            raise ValueError(
+                f"splunk search failed ({resp.status_code}): {resp.text[:500]}"
+            )
+
+        results: List[Dict[str, Any]] = []
+        # the export endpoint streams newline-delimited JSON objects
+        for line in resp.text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            row = obj.get("result")
+            if isinstance(row, dict):
+                results.append(row)
+        logger.info(f"splunk search returned {len(results)} rows")
+        return results
+
+    # ── OUTPUT: HTTP Event Collector ─────────────────────────────────
+
+    def send_event(
+        self,
+        event: Dict[str, Any],
+        sourcetype: str = "openuba",
+        source: str = "openuba",
+        index: Optional[str] = None,
+    ) -> bool:
+        '''forward a single event to Splunk via HEC. returns True on success.'''
+        if not self.hec_url or not self.hec_token:
+            logger.debug("splunk HEC not configured — skipping event forward")
+            return False
+
+        url = f"{self.hec_url}/services/collector/event"
+        body: Dict[str, Any] = {
+            "event": event,
+            "sourcetype": sourcetype,
+            "source": source,
+        }
+        if index:
+            body["index"] = index
+        try:
+            resp = requests.post(
+                url,
+                data=json.dumps(body),
+                headers={"Authorization": f"Splunk {self.hec_token}"},
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+            )
+            if resp.status_code == 200:
+                return True
+            logger.error(f"splunk HEC send failed ({resp.status_code}): {resp.text[:300]}")
+            return False
+        except Exception as e:
+            logger.error(f"splunk HEC send error: {e}")
+            return False
+
+    def send_anomaly(self, anomaly: Dict[str, Any], index: Optional[str] = None) -> bool:
+        '''forward an OpenUBA anomaly to Splunk as an openuba:anomaly event'''
+        return self.send_event(anomaly, sourcetype="openuba:anomaly", index=index)
+
+    def send_anomalies(self, anomalies: List[Dict[str, Any]], index: Optional[str] = None) -> int:
+        '''forward a batch of anomalies; returns the count successfully sent'''
+        sent = 0
+        for a in anomalies:
+            if self.send_anomaly(a, index=index):
+                sent += 1
+        return sent
+
+    # ── connectivity ─────────────────────────────────────────────────
+
+    def test_connection(self) -> Dict[str, Any]:
+        '''probe the REST management endpoint (or HEC if only that is set)'''
+        try:
+            if self.host:
+                resp = requests.get(
+                    f"{self.host}/services/server/info",
+                    params={"output_mode": "json"},
+                    headers=self._rest_headers(),
+                    auth=self._rest_auth(),
+                    verify=self.verify_ssl,
+                    timeout=10,
+                )
+                if resp.status_code == 200:
+                    version = ""
+                    try:
+                        entries = resp.json().get("entry", [])
+                        if entries:
+                            version = entries[0].get("content", {}).get("version", "")
+                    except Exception:
+                        pass
+                    return {"status": "connected", "version": version}
+                return {"status": "error", "message": f"HTTP {resp.status_code}"}
+
+            if self.hec_url and self.hec_token:
+                resp = requests.get(
+                    f"{self.hec_url}/services/collector/health",
+                    headers={"Authorization": f"Splunk {self.hec_token}"},
+                    verify=self.verify_ssl,
+                    timeout=10,
+                )
+                if resp.status_code == 200:
+                    return {"status": "connected", "channel": "hec"}
+                return {"status": "error", "message": f"HEC HTTP {resp.status_code}"}
+
+            return {"status": "error", "message": "host or hec_url not configured"}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}

--- a/core/services/model_orchestrator.py
+++ b/core/services/model_orchestrator.py
@@ -174,6 +174,9 @@ class ModelOrchestrator:
                             logger.warning(traceback.format_exc())
                     db.commit()
 
+                # optional: forward anomalies to Splunk (HEC) if configured
+                self._forward_anomalies_to_splunk(result["anomalies"])
+
             # evaluate flow rules after inference
             # NO hardcoded pre-filtering — the rule engine's flow graph conditions
             # decide what triggers. we just identify anomalies from this run.
@@ -327,6 +330,36 @@ class ModelOrchestrator:
                 log.error_traceback = traceback.format_exc()
                 db.commit()
             logger.error(f"model execution failed: {e}")
+
+    def _forward_anomalies_to_splunk(self, anomalies) -> None:
+        '''
+        best-effort: forward this run's anomalies to Splunk via HEC when the
+        'splunk' integration is enabled and has forward_anomalies set. Reuses
+        the shared SplunkConnector; never raises into the execution path.
+        '''
+        if not anomalies:
+            return
+        try:
+            from sqlalchemy import text
+            with get_db_context() as db:
+                row = db.execute(text(
+                    "SELECT config, enabled FROM integration_settings "
+                    "WHERE integration_type = 'splunk'"
+                )).fetchone()
+            if not row or not row[1]:
+                return
+            config = dict(row[0]) if row[0] else {}
+            if not config.get("forward_anomalies"):
+                return
+
+            from core.integrations.splunk import SplunkConnector
+            connector = SplunkConnector.from_config(config)
+            sent = connector.send_anomalies(
+                list(anomalies), index=config.get("anomaly_index")
+            )
+            logger.info(f"forwarded {sent}/{len(anomalies)} anomalies to splunk")
+        except Exception as e:
+            logger.warning(f"splunk anomaly forwarding failed: {e}")
 
     def execute_model_background(
         self,

--- a/core/tests/test_services/test_splunk_connector.py
+++ b/core/tests/test_services/test_splunk_connector.py
@@ -1,0 +1,188 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+splunk connector tests (issue #99)
+
+dedicated subsuite for the Splunk integration. All network calls are mocked
+(no live Splunk), so these run in the standard unit test job. Covers query
+normalization, search parsing + auth, HEC output, and connectivity probing.
+
+Lives under test_services/ (not test_integrations/) so it is included by the
+CI unit filter `-k "not e2e and not integration"`.
+'''
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.integrations import splunk as splunk_mod
+from core.integrations.splunk import SplunkConnector
+
+
+def _resp(status=200, text="", json_body=None):
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    if json_body is not None:
+        r.json.return_value = json_body
+    return r
+
+
+# ─── query normalization ─────────────────────────────────────────────────────
+
+def test_normalize_query_prepends_search():
+    assert SplunkConnector._normalize_query("index=main error") == "search index=main error"
+
+
+def test_normalize_query_leaves_search_prefixed():
+    assert SplunkConnector._normalize_query("search index=main") == "search index=main"
+
+
+def test_normalize_query_leaves_generating_command():
+    assert SplunkConnector._normalize_query("| tstats count") == "| tstats count"
+
+
+def test_normalize_query_rejects_empty():
+    with pytest.raises(ValueError):
+        SplunkConnector._normalize_query("   ")
+
+
+# ─── config ──────────────────────────────────────────────────────────────────
+
+def test_env_fallback(monkeypatch):
+    monkeypatch.setenv("SPLUNK_HOST", "https://splunk:8089/")
+    monkeypatch.setenv("SPLUNK_TOKEN", "tok")
+    monkeypatch.setenv("SPLUNK_HEC_URL", "https://splunk:8088/")
+    monkeypatch.setenv("SPLUNK_HEC_TOKEN", "hectok")
+    c = SplunkConnector()
+    assert c.host == "https://splunk:8089"      # trailing slash stripped
+    assert c.token == "tok"
+    assert c.hec_url == "https://splunk:8088"
+    assert c.hec_token == "hectok"
+
+
+def test_from_config():
+    c = SplunkConnector.from_config({
+        "host": "https://s:8089", "username": "admin", "password": "pw",
+        "verify_ssl": False,
+    })
+    assert c.host == "https://s:8089"
+    assert c.username == "admin"
+    assert c.verify_ssl is False
+
+
+# ─── search (input) ──────────────────────────────────────────────────────────
+
+def test_search_parses_ndjson_and_uses_bearer():
+    ndjson = "\n".join([
+        json.dumps({"preview": False, "offset": 0, "result": {"user": "alice", "count": "3"}}),
+        json.dumps({"result": {"user": "bob", "count": "7"}}),
+        json.dumps({"lastrow": True}),  # non-result line ignored
+        "",  # blank line ignored
+    ])
+    c = SplunkConnector(host="https://splunk:8089", token="tok")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(200, ndjson)
+        rows = c.search("index=main", max_count=500)
+
+    assert rows == [{"user": "alice", "count": "3"}, {"user": "bob", "count": "7"}]
+    args, kwargs = req.post.call_args
+    assert args[0] == "https://splunk:8089/services/search/jobs/export"
+    assert kwargs["data"]["search"] == "search index=main"
+    assert kwargs["data"]["count"] == 500
+    assert kwargs["headers"]["Authorization"] == "Bearer tok"
+    assert kwargs["auth"] is None
+
+
+def test_search_uses_basic_auth_without_token():
+    c = SplunkConnector(host="https://splunk:8089", username="admin", password="pw")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(200, "")
+        c.search("index=main")
+    _, kwargs = req.post.call_args
+    assert "Authorization" not in kwargs["headers"]
+    assert kwargs["auth"] == ("admin", "pw")
+
+
+def test_search_raises_on_error_status():
+    c = SplunkConnector(host="https://splunk:8089", token="t")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(401, "unauthorized")
+        with pytest.raises(ValueError, match="401"):
+            c.search("index=main")
+
+
+def test_search_requires_host():
+    with pytest.raises(ValueError, match="host not configured"):
+        SplunkConnector(host="").search("index=main")
+
+
+# ─── HEC output ──────────────────────────────────────────────────────────────
+
+def test_send_event_posts_to_hec_with_auth():
+    c = SplunkConnector(hec_url="https://splunk:8088", hec_token="hectok")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(200)
+        ok = c.send_event({"a": 1}, sourcetype="openuba", index="main")
+
+    assert ok is True
+    args, kwargs = req.post.call_args
+    assert args[0] == "https://splunk:8088/services/collector/event"
+    assert kwargs["headers"]["Authorization"] == "Splunk hectok"
+    body = json.loads(kwargs["data"])
+    assert body["event"] == {"a": 1}
+    assert body["index"] == "main"
+    assert body["sourcetype"] == "openuba"
+
+
+def test_send_event_returns_false_when_hec_unconfigured():
+    c = SplunkConnector()
+    assert c.send_event({"a": 1}) is False
+
+
+def test_send_event_returns_false_on_error_status():
+    c = SplunkConnector(hec_url="https://splunk:8088", hec_token="t")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(403, "forbidden")
+        assert c.send_event({"a": 1}) is False
+
+
+def test_send_anomaly_uses_anomaly_sourcetype():
+    c = SplunkConnector(hec_url="https://splunk:8088", hec_token="t")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.return_value = _resp(200)
+        c.send_anomaly({"entity_id": "u1", "risk_score": 0.9})
+    _, kwargs = req.post.call_args
+    assert json.loads(kwargs["data"])["sourcetype"] == "openuba:anomaly"
+
+
+def test_send_anomalies_counts_successes():
+    c = SplunkConnector(hec_url="https://splunk:8088", hec_token="t")
+    with patch.object(splunk_mod, "requests") as req:
+        req.post.side_effect = [_resp(200), _resp(500, "err"), _resp(200)]
+        sent = c.send_anomalies([{"a": 1}, {"a": 2}, {"a": 3}])
+    assert sent == 2
+
+
+# ─── connectivity ────────────────────────────────────────────────────────────
+
+def test_test_connection_ok():
+    c = SplunkConnector(host="https://splunk:8089", token="t")
+    body = {"entry": [{"content": {"version": "9.2.1"}}]}
+    with patch.object(splunk_mod, "requests") as req:
+        req.get.return_value = _resp(200, json_body=body)
+        result = c.test_connection()
+    assert result == {"status": "connected", "version": "9.2.1"}
+
+
+def test_test_connection_error_status():
+    c = SplunkConnector(host="https://splunk:8089", token="t")
+    with patch.object(splunk_mod, "requests") as req:
+        req.get.return_value = _resp(500)
+        result = c.test_connection()
+    assert result["status"] == "error"
+
+
+def test_test_connection_unconfigured():
+    result = SplunkConnector().test_connection()
+    assert result["status"] == "error"

--- a/core/tests/test_services/test_splunk_wiring.py
+++ b/core/tests/test_services/test_splunk_wiring.py
@@ -1,0 +1,109 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+splunk wiring tests (issue #99)
+
+covers the settings integration (whitelist, masking, connectivity dispatch)
+and the orchestrator's best-effort anomaly forwarding. Fully mocked.
+'''
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.api_routers.settings import VALID_INTEGRATION_TYPES, _mask_sensitive_fields
+from core.services import model_orchestrator as orch_mod
+from core.services.model_orchestrator import ModelOrchestrator
+
+
+# ─── settings wiring ─────────────────────────────────────────────────────────
+
+def test_splunk_whitelisted():
+    assert "splunk" in VALID_INTEGRATION_TYPES
+
+
+def test_splunk_secrets_masked():
+    masked = _mask_sensitive_fields({
+        "token": "abcdef123456", "hec_token": "hectoken12345",
+        "password": "pw12345678", "host": "https://s:8089",
+    })
+    assert masked["token"] != "abcdef123456"
+    assert masked["hec_token"] != "hectoken12345"
+    assert masked["password"] != "pw12345678"
+    assert masked["host"] == "https://s:8089"
+
+
+@pytest.mark.asyncio
+async def test_test_splunk_delegates_to_connector():
+    from core.api_routers.settings import _test_splunk
+    with patch("core.integrations.splunk.SplunkConnector.test_connection",
+               return_value={"status": "connected", "version": "9.0"}):
+        result = await _test_splunk({"host": "https://s:8089", "token": "t"})
+    assert result["status"] == "connected"
+
+
+# ─── orchestrator forwarding ─────────────────────────────────────────────────
+
+def _patch_db_with_splunk_row(config, enabled=True):
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = (config, enabled)
+
+    @contextmanager
+    def ctx():
+        yield db
+
+    return ctx
+
+
+def test_forward_skips_when_no_anomalies():
+    orch = ModelOrchestrator()
+    with patch("core.integrations.splunk.SplunkConnector") as conn_cls:
+        orch._forward_anomalies_to_splunk([])
+    conn_cls.assert_not_called()
+
+
+def test_forward_skips_when_disabled():
+    orch = ModelOrchestrator()
+    ctx = _patch_db_with_splunk_row({"forward_anomalies": True}, enabled=False)
+    with patch.object(orch_mod, "get_db_context", ctx), \
+         patch("core.integrations.splunk.SplunkConnector") as conn_cls:
+        orch._forward_anomalies_to_splunk([{"a": 1}])
+    conn_cls.assert_not_called()
+
+
+def test_forward_skips_when_flag_off():
+    orch = ModelOrchestrator()
+    ctx = _patch_db_with_splunk_row({"forward_anomalies": False, "hec_url": "x"})
+    with patch.object(orch_mod, "get_db_context", ctx), \
+         patch("core.integrations.splunk.SplunkConnector") as conn_cls:
+        orch._forward_anomalies_to_splunk([{"a": 1}])
+    conn_cls.assert_not_called()
+
+
+def test_forward_sends_when_enabled_and_flagged():
+    orch = ModelOrchestrator()
+    ctx = _patch_db_with_splunk_row({
+        "forward_anomalies": True, "hec_url": "https://s:8088",
+        "hec_token": "t", "anomaly_index": "openuba",
+    })
+    anomalies = [{"entity_id": "u1"}, {"entity_id": "u2"}]
+    with patch.object(orch_mod, "get_db_context", ctx), \
+         patch("core.integrations.splunk.SplunkConnector") as conn_cls:
+        conn_cls.from_config.return_value.send_anomalies.return_value = 2
+        orch._forward_anomalies_to_splunk(anomalies)
+    conn_cls.from_config.return_value.send_anomalies.assert_called_once_with(
+        anomalies, index="openuba"
+    )
+
+
+def test_forward_never_raises_on_error():
+    orch = ModelOrchestrator()
+
+    @contextmanager
+    def boom():
+        raise RuntimeError("db down")
+        yield  # pragma: no cover
+
+    with patch.object(orch_mod, "get_db_context", boom):
+        # must not raise
+        orch._forward_anomalies_to_splunk([{"a": 1}])

--- a/docker/model-runner/runner.py
+++ b/docker/model-runner/runner.py
@@ -394,6 +394,58 @@ def _load_data_for_model(input_data: dict):
             else:
                 raise ValueError(f"elasticsearch query failed ({resp.status_code}): {resp.text[:500]}")
 
+        elif data_source == "splunk":
+            search = input_data.get("splunk_search") or input_data.get("search")
+            if not search:
+                raise ValueError("splunk_search required for splunk data source")
+            host = (input_data.get("host") or os.getenv("SPLUNK_HOST", "")).rstrip("/")
+            if not host:
+                raise ValueError("SPLUNK_HOST not configured")
+            token = os.getenv("SPLUNK_TOKEN", "")
+            username = os.getenv("SPLUNK_USERNAME", "")
+            password = os.getenv("SPLUNK_PASSWORD", "")
+            verify_ssl = os.getenv("SPLUNK_VERIFY_SSL", "true").lower() in ("1", "true", "yes", "on")
+
+            q = search.strip()
+            if not (q.startswith("|") or q.lower().startswith("search ")):
+                q = "search " + q
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            auth = (username, password) if (not token and username) else None
+            payload = {
+                "search": q,
+                "output_mode": "json",
+                "earliest_time": input_data.get("earliest_time", "-24h"),
+                "latest_time": input_data.get("latest_time", "now"),
+                "count": input_data.get("size", 10000),
+            }
+            url = f"{host}/services/search/jobs/export"
+            logger.info(f"querying splunk: {url}")
+            resp = requests.post(url, data=payload, headers=headers, auth=auth,
+                                 verify=verify_ssl, timeout=120)
+            if resp.status_code != 200:
+                raise ValueError(f"splunk search failed ({resp.status_code}): {resp.text[:500]}")
+            rows = []
+            for line in resp.text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                r = obj.get("result")
+                if isinstance(r, dict):
+                    rows.append(r)
+            df = pd.DataFrame(rows)
+            for col in df.columns:
+                converted = pd.to_numeric(df[col], errors="coerce")
+                if converted.notna().mean() > 0.5:
+                    df[col] = converted
+            logger.info(f"loaded {len(df)} rows from splunk search")
+            return df
+
         elif data_source == "spark":
             table_name = input_data.get("table_name")
             if not table_name:

--- a/docs/SPLUNK.md
+++ b/docs/SPLUNK.md
@@ -1,0 +1,66 @@
+# Splunk Integration
+
+OpenUBA integrates with Splunk in both directions:
+
+- **Input** — run a Splunk search and feed the results to a model as a data source.
+- **Output** — forward detected anomalies back to Splunk via the HTTP Event Collector (HEC).
+
+## Configuration
+
+Configure Splunk under **Settings → Integrations → Splunk**, or via the API
+(`PUT /api/v1/settings/integrations/splunk`). Config is stored in the
+`integration_settings` table (no secrets in manifests) and the token / HEC
+token / password are masked on read.
+
+| Field | Purpose |
+|---|---|
+| `host` | REST management endpoint, e.g. `https://splunk:8089` (used for search) |
+| `token` | REST bearer token (preferred), **or** |
+| `username` / `password` | basic auth for the REST API |
+| `hec_url` | HTTP Event Collector base, e.g. `https://splunk:8088` (used for output) |
+| `hec_token` | HEC token |
+| `anomaly_index` | Splunk index anomalies are forwarded to |
+| `forward_anomalies` | when on, each inference run forwards its anomalies to Splunk |
+| `verify_ssl` | verify TLS certificates (default on) |
+
+Use **Test** in the settings panel to verify connectivity.
+
+The model-runner container reads the same values from the environment when it
+executes a search: `SPLUNK_HOST`, `SPLUNK_TOKEN`, `SPLUNK_USERNAME`,
+`SPLUNK_PASSWORD`, `SPLUNK_VERIFY_SSL`.
+
+## Using Splunk as a data source
+
+Select `splunk` as the data source when training or running a model and pass a
+search. Via the API:
+
+```bash
+curl -X POST "$API/api/v1/models/$MODEL_ID/execute" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+        "data_source": "splunk",
+        "splunk_search": "index=proxy sourcetype=access_combined",
+        "splunk_index": "proxy"
+      }'
+```
+
+The search runs against the export endpoint and the result rows are handed to
+the model as a DataFrame (numeric columns are coerced automatically). Searches
+that don't start with `search` or a generating command (`|`) are prefixed with
+`search` for you.
+
+## Forwarding anomalies to Splunk
+
+Enable **Forward anomalies to Splunk** in the integration config. After each
+inference run, OpenUBA sends every anomaly to HEC as an `openuba:anomaly`
+event in the configured `anomaly_index`. Forwarding is best-effort — a Splunk
+outage never affects detection or persistence.
+
+You can also forward events directly from Python:
+
+```python
+from core.integrations import SplunkConnector
+
+splunk = SplunkConnector(hec_url="https://splunk:8088", hec_token="...")
+splunk.send_anomaly({"entity_id": "u123", "risk_score": 0.97}, index="openuba")
+```

--- a/interface/src/components/settings/settings-tabs.tsx
+++ b/interface/src/components/settings/settings-tabs.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
-import { Plus, Trash2, Edit2, X, Loader2, CheckCircle2, XCircle, Zap, Brain, Bot, Sparkles, Database, Cpu, Save, Shield } from "lucide-react"
+import { Plus, Trash2, Edit2, X, Loader2, CheckCircle2, XCircle, Zap, Brain, Bot, Sparkles, Database, Cpu, Save, Shield, Search } from "lucide-react"
 import { useAuth } from '@/lib/auth-provider'
 import { useUIStore } from '@/lib/state/ui-store'
 
@@ -22,7 +22,7 @@ function getAuthHeaders(): Record<string, string> {
     return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-type IntegrationType = 'ollama' | 'openai' | 'claude' | 'gemini' | 'elasticsearch' | 'spark'
+type IntegrationType = 'ollama' | 'openai' | 'claude' | 'gemini' | 'elasticsearch' | 'spark' | 'splunk'
 
 interface IntegrationDef {
     type: IntegrationType
@@ -140,6 +140,25 @@ const INTEGRATION_DEFS: IntegrationDef[] = [
                     { value: 'cluster', label: 'Cluster' },
                 ],
             },
+        ],
+    },
+    {
+        type: 'splunk',
+        name: 'Splunk',
+        description: 'Search Splunk as a data source and forward anomalies via HEC',
+        category: 'data',
+        icon: <Search className="h-5 w-5" />,
+        color: 'text-lime-500 bg-lime-500/10',
+        fields: [
+            { key: 'host', label: 'Management URL', type: 'text', placeholder: 'https://splunk:8089' },
+            { key: 'token', label: 'REST Token', type: 'password', placeholder: 'Bearer token (or use username/password)' },
+            { key: 'username', label: 'Username', type: 'text', placeholder: 'admin' },
+            { key: 'password', label: 'Password', type: 'password', placeholder: '' },
+            { key: 'hec_url', label: 'HEC URL', type: 'text', placeholder: 'https://splunk:8088' },
+            { key: 'hec_token', label: 'HEC Token', type: 'password', placeholder: '' },
+            { key: 'anomaly_index', label: 'Anomaly Index (output)', type: 'text', placeholder: 'openuba' },
+            { key: 'forward_anomalies', label: 'Forward anomalies to Splunk', type: 'toggle' },
+            { key: 'verify_ssl', label: 'Verify SSL', type: 'toggle' },
         ],
     },
 ]


### PR DESCRIPTION
## What

Integrates Splunk in both directions (requested in #99):

- **Input** — run a Splunk search and feed the results to a model as a data source.
- **Output** — forward detected anomalies back to Splunk via HEC.

## How it reuses existing infrastructure

- **`SplunkConnector`** (`core/integrations/splunk.py`) sits alongside `ElasticsearchConnector` / `SparkConnector` — REST **export** search for input, **HTTP Event Collector** for output, bearer or basic auth. Config via `integration_settings` (`from_config`) or `SPLUNK_*` env.
- **Model runner** gains a `splunk` branch in `_load_data_for_model`, mirroring the elasticsearch branch (self-contained `requests`, returns a DataFrame with numeric coercion).
- **train/execute endpoints** get `splunk_search` / `splunk_index` params + a dispatch branch, exactly like the existing `spark` / `elasticsearch` / `source_group` sources.
- **Orchestrator** forwards each inference run's anomalies to Splunk HEC when `forward_anomalies` is enabled — best-effort, so a Splunk outage never affects detection or persistence.
- **Settings**: `splunk` registered in the whitelist, secrets (`token`/`hec_token`/`password`) masked, `/test` connectivity probe, and a Splunk card in the Data Engines settings panel.
- **Docs**: `docs/SPLUNK.md`.

## Tests (dedicated subsuite, CI-wired)

`core/tests/test_services/test_splunk_connector.py` + `test_splunk_wiring.py` — **26 unit tests**, all mocked (no live Splunk): SPL normalization, search parsing + bearer/basic auth, error handling, HEC output + auth header, batch send counts, connectivity probe, settings whitelist/masking/`_test_splunk`, and orchestrator forwarding gating (enabled/disabled/flag-off/error-safe). Placed under `test_services/` so they run in the CI unit job (the `-k` filter excludes anything under `test_integrations/`).

Local: 26/26 green, runner compiles, `tsc`/`next lint`/`next build` all clean.

## Follow-up (not in this PR)

Splunk-as-a-physical-source inside `source_groups` (so a source group can mix Splunk with other sources) is a natural next step.

Closes #99