### PR TITLE
feat(data): dataset ingestion + detection evaluation (#35) [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 venv/
+.venv/
 .pytest_cache/
 .mypy_cache/
 *.log

--- a/core/api_routers/anomalies.py
+++ b/core/api_routers/anomalies.py
@@ -46,6 +46,7 @@ async def create_anomaly(
 async def list_anomalies(
     model_id: Optional[UUID] = Query(None),
     entity_id: Optional[str] = Query(None),
+    run_id: Optional[UUID] = Query(None, description="filter to a single model run's anomalies"),
     acknowledged: Optional[bool] = Query(None),
     min_risk_score: Optional[float] = Query(None, ge=0.0, le=100.0),
     max_risk_score: Optional[float] = Query(None, ge=0.0, le=100.0),
@@ -62,6 +63,7 @@ async def list_anomalies(
     anomalies = repo.list_all(
         model_id=model_id,
         entity_id=entity_id,
+        run_id=run_id,
         acknowledged=acknowledged,
         min_risk_score=min_risk_score,
         max_risk_score=max_risk_score,

--- a/core/api_routers/evaluation.py
+++ b/core/api_routers/evaluation.py
@@ -1,0 +1,66 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+evaluation api router — score a model run's anomalies against known ground truth.
+
+Reads a run's anomalies (by run_id) and scores them with the shared
+core.services.detection_eval scorer. The result shape is JSONB-friendly so
+callers can store it in an ExperimentRun.metrics for comparison (issue #35).
+'''
+
+import logging
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.db import get_db
+from core.repositories.anomaly_repository import AnomalyRepository
+from core.services.detection_eval import evaluate_detections
+from core.auth import require_permission
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class EvaluateRunRequest(BaseModel):
+    run_id: UUID
+    malicious_entities: List[str] = Field(..., description="ground-truth malicious entity ids")
+    all_entities: Optional[List[str]] = Field(None, description="full population for TN / FP-rate")
+    threshold: float = Field(50.0, ge=0.0, le=100.0, description="risk_score to count as flagged")
+    scenarios: Optional[Dict[str, List[str]]] = Field(None, description="scenario -> entity ids for per-scenario recall")
+
+
+@router.post("/evaluate/run")
+async def evaluate_run(
+    body: EvaluateRunRequest,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(require_permission("anomalies", "read")),
+):
+    '''
+    score one model run's detections against a labeled ground-truth entity set.
+    returns precision / recall / F1 / false-positive-rate (+ per-scenario recall).
+    '''
+    repo = AnomalyRepository(db)
+    rows = repo.list_all(run_id=body.run_id, limit=100000)
+    anomalies = [
+        {
+            "entity_id": r.entity_id,
+            "risk_score": float(r.risk_score) if r.risk_score is not None else 0.0,
+            "anomaly_type": r.anomaly_type,
+        }
+        for r in rows
+    ]
+    result = evaluate_detections(
+        anomalies=anomalies,
+        malicious_entities=body.malicious_entities,
+        all_entities=body.all_entities,
+        threshold=body.threshold,
+        scenarios=body.scenarios,
+    )
+    logger.info(
+        f"evaluated run {body.run_id}: precision={result.precision} "
+        f"recall={result.recall} over {len(anomalies)} anomalies"
+    )
+    return result.to_dict()

--- a/core/fastapi_app.py
+++ b/core/fastapi_app.py
@@ -271,6 +271,7 @@ app.include_router(system.router, tags=["system"])
 # workspace & platform enhancement routers
 from core.api_routers import workspaces, jobs, visualizations, dashboards
 from core.api_routers import features, experiments, hyperparameters, pipelines, datasets, sdk
+from core.api_routers import evaluation
 app.include_router(workspaces.router, prefix="/api/v1", tags=["workspaces"])
 app.include_router(jobs.router, prefix="/api/v1", tags=["jobs"])
 app.include_router(visualizations.router, prefix="/api/v1", tags=["visualizations"])
@@ -281,6 +282,7 @@ app.include_router(hyperparameters.router, prefix="/api/v1", tags=["hyperparamet
 app.include_router(pipelines.router, prefix="/api/v1", tags=["pipelines"])
 app.include_router(datasets.router, prefix="/api/v1", tags=["datasets"])
 app.include_router(sdk.router, prefix="/api/v1", tags=["sdk"])
+app.include_router(evaluation.router, prefix="/api/v1", tags=["evaluation"])
 
 
 @app.get("/")

--- a/core/repositories/anomaly_repository.py
+++ b/core/repositories/anomaly_repository.py
@@ -62,6 +62,7 @@ class AnomalyRepository:
         self,
         model_id: Optional[UUID] = None,
         entity_id: Optional[str] = None,
+        run_id: Optional[UUID] = None,
         acknowledged: Optional[bool] = None,
         min_risk_score: Optional[float] = None,
         max_risk_score: Optional[float] = None,
@@ -78,6 +79,8 @@ class AnomalyRepository:
             query = query.filter(Anomaly.model_id == model_id)
         if entity_id:
             query = query.filter(Anomaly.entity_id == entity_id)
+        if run_id:
+            query = query.filter(Anomaly.run_id == run_id)
         if acknowledged is not None:
             query = query.filter(Anomaly.acknowledged == acknowledged)
         if min_risk_score is not None:

--- a/core/services/data_ingestion.py
+++ b/core/services/data_ingestion.py
@@ -417,10 +417,18 @@ class DataIngestionService:
             for item in adjusted_path.iterdir():
                 if item.is_dir() and not item.name.startswith("."):
                     dataset_name = item.name
-                    
-                    # STRICT WHITELIST: only allow toy_1 (user request)
-                    if dataset_name != "toy_1":
-                        logger.warning(f"skipping invalid dataset: {dataset_name} (only 'toy_1' is allowed per user rule)")
+
+                    # Ingest any directory that looks like a dataset, i.e. it holds
+                    # at least one log-type subdirectory (proxy/dns/ssh/...). This
+                    # keeps toy_1 working while allowing additional datasets to be
+                    # added under test_datasets/ without a code change, and safely
+                    # skips stray/non-dataset directories.
+                    has_log_types = any(
+                        sub.is_dir() and not sub.name.startswith(".")
+                        for sub in item.iterdir()
+                    )
+                    if not has_log_types:
+                        logger.debug(f"skipping {dataset_name}: no log-type subdirectories")
                         continue
 
                     logger.info(f"found dataset: {dataset_name}")

--- a/core/services/detection_eval.py
+++ b/core/services/detection_eval.py
@@ -1,0 +1,140 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+detection evaluation — score a model run's anomalies against known ground truth.
+
+This is the one genuinely-new capability behind issue #35 ("Data Ingestion &
+Testing"): given the anomalies a run produced and the set of entities that are
+known to be malicious in a labeled dataset, compute standard detection metrics
+(precision / recall / F1 / false-positive rate) at the ENTITY level.
+
+Deliberately dependency-light (pure Python stdlib, 3.9-compatible) so it runs in
+the unit test job with no infra. The results are meant to be stored in the
+existing ExperimentRun.metrics (JSONB) via the experiments API/SDK, and the
+ground-truth labels can be persisted through the existing UserFeedback surface —
+this module only computes the math.
+'''
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+
+@dataclass
+class EvaluationResult:
+    '''entity-level detection metrics for one run against a labeled dataset'''
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+    false_positive_rate: float
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    true_negatives: int
+    flagged_entities: List[str] = field(default_factory=list)
+    missed_entities: List[str] = field(default_factory=list)
+    # recall per scenario/anomaly-type when the ground truth carries scenarios
+    per_scenario_recall: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        '''shape suitable for ExperimentRun.metrics (JSONB)'''
+        return asdict(self)
+
+
+def _entity_of(anomaly: Any) -> Optional[str]:
+    '''pull the entity id from an anomaly dict or ORM row'''
+    if isinstance(anomaly, dict):
+        val = anomaly.get("entity_id")
+    else:
+        val = getattr(anomaly, "entity_id", None)
+    return None if val is None else str(val)
+
+
+def _risk_of(anomaly: Any) -> float:
+    if isinstance(anomaly, dict):
+        val = anomaly.get("risk_score")
+    else:
+        val = getattr(anomaly, "risk_score", None)
+    try:
+        return float(val) if val is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def flagged_entities(anomalies: Iterable[Any], threshold: float = 50.0) -> Set[str]:
+    '''
+    entities the run flagged: any entity with an anomaly whose risk_score meets
+    the threshold. Mirrors how OpenUBA models emit one anomaly per event with a
+    0-100 risk_score, so an entity is "flagged" if any of its events scored high.
+    '''
+    out: Set[str] = set()
+    for a in anomalies:
+        ent = _entity_of(a)
+        if ent is None:
+            continue
+        if _risk_of(a) >= threshold:
+            out.add(ent)
+    return out
+
+
+def evaluate_detections(
+    anomalies: Iterable[Any],
+    malicious_entities: Iterable[str],
+    all_entities: Optional[Iterable[str]] = None,
+    threshold: float = 50.0,
+    scenarios: Optional[Dict[str, Iterable[str]]] = None,
+) -> EvaluationResult:
+    '''
+    Score a run's anomalies against ground truth.
+
+    anomalies          — the run's anomalies (dicts or ORM rows with
+                         entity_id + risk_score); typically read by run_id.
+    malicious_entities — ground-truth set of entity_ids that are truly bad.
+    all_entities       — the full population the run covered (to count true
+                         negatives / false-positive rate). If omitted, it is the
+                         union of malicious + flagged (TNR then unknown → 0 TNs).
+    threshold          — risk_score at/above which an entity counts as flagged.
+    scenarios          — optional {scenario_name: [entity_ids]} for per-scenario recall.
+    '''
+    malicious: Set[str] = {str(e) for e in malicious_entities}
+    flagged: Set[str] = flagged_entities(anomalies, threshold)
+
+    population: Set[str]
+    if all_entities is not None:
+        population = {str(e) for e in all_entities} | malicious | flagged
+    else:
+        population = malicious | flagged
+    benign = population - malicious
+
+    tp = len(flagged & malicious)
+    fp = len(flagged & benign)
+    fn = len(malicious - flagged)
+    tn = len(benign - flagged)
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    fpr = fp / (fp + tn) if (fp + tn) else 0.0
+
+    per_scenario: Dict[str, float] = {}
+    if scenarios:
+        for name, ents in scenarios.items():
+            ents_set = {str(e) for e in ents}
+            if not ents_set:
+                continue
+            caught = len(ents_set & flagged)
+            per_scenario[name] = caught / len(ents_set)
+
+    return EvaluationResult(
+        threshold=float(threshold),
+        precision=round(precision, 6),
+        recall=round(recall, 6),
+        f1=round(f1, 6),
+        false_positive_rate=round(fpr, 6),
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        true_negatives=tn,
+        flagged_entities=sorted(flagged),
+        missed_entities=sorted(malicious - flagged),
+        per_scenario_recall=per_scenario,
+    )

--- a/core/tests/test_api_routers/test_evaluation.py
+++ b/core/tests/test_api_routers/test_evaluation.py
@@ -6,7 +6,19 @@ end-to-end through the API: seed a run + anomalies, POST /evaluate/run, and
 check the detection metrics come back correct.
 '''
 
+import pytest
 from fastapi.testclient import TestClient
+
+from core.fastapi_app import app
+from core.auth import get_current_user
+
+
+@pytest.fixture
+def admin_auth():
+    '''inject an admin caller so require_permission passes (admin bypasses checks)'''
+    app.dependency_overrides[get_current_user] = lambda: {"role": "admin", "username": "tester"}
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 def _seed_run_with_anomalies(db_session):
@@ -15,7 +27,8 @@ def _seed_run_with_anomalies(db_session):
     from core.db.models import ModelVersion, ModelRun
 
     model = ModelRepository(db_session).create(
-        name="eval_api_model", version="1.0.0", source_type="local_fs")
+        name="eval_api_model", version="1.0.0", source_type="local_fs",
+        slug="eval-api-model")
     ver = ModelVersion(model_id=model.id, version="1.0.0", status="registered")
     db_session.add(ver)
     db_session.flush()
@@ -29,7 +42,7 @@ def _seed_run_with_anomalies(db_session):
     return run
 
 
-def test_evaluate_run_scores_detections(test_client: TestClient, db_session):
+def test_evaluate_run_scores_detections(test_client: TestClient, db_session, admin_auth):
     run = _seed_run_with_anomalies(db_session)
 
     resp = test_client.post("/api/v1/evaluate/run", json={
@@ -50,7 +63,7 @@ def test_evaluate_run_scores_detections(test_client: TestClient, db_session):
         assert k in m
 
 
-def test_evaluate_run_empty_run_is_safe(test_client: TestClient, db_session):
+def test_evaluate_run_empty_run_is_safe(test_client: TestClient, db_session, admin_auth):
     run = _seed_run_with_anomalies(db_session)
     # a run_id with no matching anomalies → zero metrics, no error
     from uuid import uuid4

--- a/core/tests/test_api_routers/test_evaluation.py
+++ b/core/tests/test_api_routers/test_evaluation.py
@@ -1,0 +1,64 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+tests for the evaluation api router (issue #35)
+
+end-to-end through the API: seed a run + anomalies, POST /evaluate/run, and
+check the detection metrics come back correct.
+'''
+
+from fastapi.testclient import TestClient
+
+
+def _seed_run_with_anomalies(db_session):
+    from core.repositories.model_repository import ModelRepository
+    from core.repositories.anomaly_repository import AnomalyRepository
+    from core.db.models import ModelVersion, ModelRun
+
+    model = ModelRepository(db_session).create(
+        name="eval_api_model", version="1.0.0", source_type="local_fs")
+    ver = ModelVersion(model_id=model.id, version="1.0.0", status="registered")
+    db_session.add(ver)
+    db_session.flush()
+    run = ModelRun(model_version_id=ver.id, run_type="infer", status="succeeded")
+    db_session.add(run)
+    db_session.flush()
+
+    ar = AnomalyRepository(db_session)
+    ar.create(model_id=model.id, entity_id="bad1", risk_score=95, run_id=run.id)
+    ar.create(model_id=model.id, entity_id="good1", risk_score=10, run_id=run.id)
+    return run
+
+
+def test_evaluate_run_scores_detections(test_client: TestClient, db_session):
+    run = _seed_run_with_anomalies(db_session)
+
+    resp = test_client.post("/api/v1/evaluate/run", json={
+        "run_id": str(run.id),
+        "malicious_entities": ["bad1", "bad2"],
+        "all_entities": ["bad1", "bad2", "good1"],
+        "threshold": 50,
+    })
+    assert resp.status_code == 200, resp.text
+    m = resp.json()
+    # bad1 flagged (TP), bad2 never flagged (FN), good1 below threshold (TN)
+    assert m["true_positives"] == 1
+    assert m["false_negatives"] == 1
+    assert m["recall"] == 0.5
+    assert m["precision"] == 1.0
+    assert m["missed_entities"] == ["bad2"]
+    for k in ("f1", "false_positive_rate", "threshold"):
+        assert k in m
+
+
+def test_evaluate_run_empty_run_is_safe(test_client: TestClient, db_session):
+    run = _seed_run_with_anomalies(db_session)
+    # a run_id with no matching anomalies → zero metrics, no error
+    from uuid import uuid4
+    resp = test_client.post("/api/v1/evaluate/run", json={
+        "run_id": str(uuid4()),
+        "malicious_entities": ["bad1"],
+        "all_entities": ["bad1", "good1"],
+    })
+    assert resp.status_code == 200, resp.text
+    m = resp.json()
+    assert m["recall"] == 0.0 and m["true_positives"] == 0

--- a/core/tests/test_repositories.py
+++ b/core/tests/test_repositories.py
@@ -75,7 +75,8 @@ def test_anomaly_repository_run_id_filter(db_session):
     from core.db.models import ModelVersion, ModelRun
 
     model_repo = ModelRepository(db_session)
-    model = model_repo.create(name="run_filter_model", version="1.0.0", source_type="local_fs")
+    model = model_repo.create(name="run_filter_model", version="1.0.0",
+                              source_type="local_fs", slug="run-filter-model")
 
     version = ModelVersion(model_id=model.id, version="1.0.0", status="registered")
     db_session.add(version)

--- a/core/tests/test_repositories.py
+++ b/core/tests/test_repositories.py
@@ -67,6 +67,37 @@ def test_anomaly_repository_create(db_session):
     assert anomaly.risk_score == 75.5
 
 
+def test_anomaly_repository_run_id_filter(db_session):
+    '''
+    anomalies can be listed scoped to a single model run — the read path detection
+    evaluation uses to score one run's output (issue #35).
+    '''
+    from core.db.models import ModelVersion, ModelRun
+
+    model_repo = ModelRepository(db_session)
+    model = model_repo.create(name="run_filter_model", version="1.0.0", source_type="local_fs")
+
+    version = ModelVersion(model_id=model.id, version="1.0.0", status="registered")
+    db_session.add(version)
+    db_session.flush()
+
+    run1 = ModelRun(model_version_id=version.id, run_type="infer", status="succeeded")
+    run2 = ModelRun(model_version_id=version.id, run_type="infer", status="succeeded")
+    db_session.add_all([run1, run2])
+    db_session.flush()
+
+    anomaly_repo = AnomalyRepository(db_session)
+    anomaly_repo.create(model_id=model.id, entity_id="e1", risk_score=90, run_id=run1.id)
+    anomaly_repo.create(model_id=model.id, entity_id="e2", risk_score=80, run_id=run1.id)
+    anomaly_repo.create(model_id=model.id, entity_id="e3", risk_score=70, run_id=run2.id)
+
+    assert {a.entity_id for a in anomaly_repo.list_all(run_id=run1.id)} == {"e1", "e2"}
+    assert {a.entity_id for a in anomaly_repo.list_all(run_id=run2.id)} == {"e3"}
+    # unfiltered still returns everything
+    all_ids = {a.entity_id for a in anomaly_repo.list_all()}
+    assert {"e1", "e2", "e3"}.issubset(all_ids)
+
+
 def test_case_repository_create(db_session):
     '''
     test creating a case

--- a/core/tests/test_services/test_data_ingestion_scan.py
+++ b/core/tests/test_services/test_data_ingestion_scan.py
@@ -1,0 +1,58 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+data-ingestion dataset-scan tests (issue #35)
+
+verifies that ingest_all_datasets discovers any real dataset under
+TEST_DATASETS_PATH (not just toy_1) while skipping non-dataset directories.
+No Spark/ES/DB needed — the physical ingest is mocked.
+'''
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.services.data_ingestion import DataIngestionService
+
+
+def _make_tree(root):
+    '''a test_datasets/ tree with two real datasets, a junk dir, and a stray file'''
+    (root / "toy_1" / "proxy").mkdir(parents=True)
+    (root / "toy_1" / "proxy" / "bluecoat.log").write_text("x\n")
+    (root / "synth_x" / "ssh").mkdir(parents=True)
+    (root / "synth_x" / "ssh" / "ssh.log").write_text("x\n")
+    (root / "empty_dir").mkdir()               # no log-type subdirs → skipped
+    (root / "labels.json").write_text("{}")    # a file, not a dir → skipped
+    (root / ".hidden").mkdir()                 # hidden → skipped
+
+
+def test_ingest_all_discovers_every_real_dataset(tmp_path, monkeypatch):
+    monkeypatch.setenv("TEST_DATASETS_PATH", str(tmp_path))
+    _make_tree(tmp_path)
+
+    svc = DataIngestionService()
+    # avoid any real Spark/ES work — record which datasets get ingested
+    svc.ingest_from_test_datasets = MagicMock(return_value={"status": "success"})
+
+    result = svc.ingest_all_datasets(ingest_to_spark=False, ingest_to_es=False)
+
+    ingested = {c.kwargs.get("dataset_name") or c.args[0]
+                for c in svc.ingest_from_test_datasets.call_args_list}
+    assert ingested == {"toy_1", "synth_x"}          # both real datasets
+    assert "empty_dir" not in ingested               # junk dir skipped
+    assert result["total_datasets"] == 2
+
+
+def test_toy_1_still_ingests_alone(tmp_path, monkeypatch):
+    '''back-compat: a tree with only toy_1 behaves exactly as before'''
+    monkeypatch.setenv("TEST_DATASETS_PATH", str(tmp_path))
+    (tmp_path / "toy_1" / "dns").mkdir(parents=True)
+    (tmp_path / "toy_1" / "dns" / "dns.log").write_text("x\n")
+
+    svc = DataIngestionService()
+    svc.ingest_from_test_datasets = MagicMock(return_value={"status": "success"})
+    result = svc.ingest_all_datasets(ingest_to_spark=False, ingest_to_es=False)
+
+    assert result["total_datasets"] == 1
+    svc.ingest_from_test_datasets.assert_called_once()
+    call = svc.ingest_from_test_datasets.call_args
+    assert (call.kwargs.get("dataset_name") or call.args[0]) == "toy_1"

--- a/core/tests/test_services/test_detection_eval.py
+++ b/core/tests/test_services/test_detection_eval.py
@@ -1,0 +1,112 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+detection evaluation tests (issue #35)
+
+pure unit tests for the entity-level scoring used to evaluate a model run
+against a labeled dataset. No DB/Docker — runs in the CI unit job.
+'''
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.services.detection_eval import (
+    EvaluationResult,
+    evaluate_detections,
+    flagged_entities,
+)
+
+
+def _anom(entity_id, risk_score, anomaly_type="statistical_outlier"):
+    return {"entity_id": entity_id, "risk_score": risk_score, "anomaly_type": anomaly_type}
+
+
+# ─── flagged_entities ────────────────────────────────────────────────────────
+
+def test_flagged_entities_respects_threshold():
+    anoms = [_anom("u1", 90), _anom("u2", 20), _anom("u3", 50)]
+    assert flagged_entities(anoms, threshold=50) == {"u1", "u3"}
+    assert flagged_entities(anoms, threshold=95) == set()
+
+
+def test_flagged_entities_dedups_multiple_events_per_entity():
+    anoms = [_anom("u1", 60), _anom("u1", 80), _anom("u1", 10)]
+    assert flagged_entities(anoms, threshold=50) == {"u1"}
+
+
+def test_flagged_entities_handles_orm_rows_and_bad_values():
+    rows = [SimpleNamespace(entity_id="u1", risk_score="88"),
+            SimpleNamespace(entity_id="u2", risk_score=None),
+            SimpleNamespace(entity_id=None, risk_score=99)]
+    assert flagged_entities(rows, threshold=50) == {"u1"}
+
+
+# ─── evaluate_detections ─────────────────────────────────────────────────────
+
+def test_perfect_detection():
+    anoms = [_anom("bad1", 95), _anom("bad2", 80)]
+    r = evaluate_detections(anoms, malicious_entities=["bad1", "bad2"],
+                            all_entities=["bad1", "bad2", "good1", "good2"], threshold=50)
+    assert isinstance(r, EvaluationResult)
+    assert r.precision == 1.0 and r.recall == 1.0 and r.f1 == 1.0
+    assert r.false_positive_rate == 0.0
+    assert r.true_positives == 2 and r.false_negatives == 0
+    assert r.false_positives == 0 and r.true_negatives == 2
+    assert r.missed_entities == []
+
+
+def test_missed_malicious_lowers_recall():
+    anoms = [_anom("bad1", 95)]  # bad2 not flagged
+    r = evaluate_detections(anoms, malicious_entities=["bad1", "bad2"],
+                            all_entities=["bad1", "bad2", "good1"], threshold=50)
+    assert r.recall == 0.5
+    assert r.false_negatives == 1
+    assert r.missed_entities == ["bad2"]
+
+
+def test_false_positive_lowers_precision():
+    anoms = [_anom("bad1", 95), _anom("good1", 88)]
+    r = evaluate_detections(anoms, malicious_entities=["bad1"],
+                            all_entities=["bad1", "good1", "good2"], threshold=50)
+    assert r.recall == 1.0
+    assert r.precision == 0.5
+    assert r.false_positives == 1
+    # fpr = fp / (fp+tn) = 1 / (1 + 1) = 0.5  (good2 is a true negative)
+    assert r.false_positive_rate == 0.5
+
+
+def test_threshold_gates_low_risk_events():
+    anoms = [_anom("bad1", 40)]  # below threshold → not flagged
+    r = evaluate_detections(anoms, malicious_entities=["bad1"],
+                            all_entities=["bad1", "good1"], threshold=50)
+    assert r.recall == 0.0 and r.true_positives == 0 and r.false_negatives == 1
+
+
+def test_per_scenario_recall():
+    anoms = [_anom("exfil1", 95), _anom("brute1", 90)]  # beacon1 missed
+    r = evaluate_detections(
+        anoms,
+        malicious_entities=["exfil1", "brute1", "beacon1"],
+        all_entities=["exfil1", "brute1", "beacon1", "good1"],
+        threshold=50,
+        scenarios={"data_exfil": ["exfil1"], "brute_force": ["brute1"], "dns_beacon": ["beacon1"]},
+    )
+    assert r.per_scenario_recall["data_exfil"] == 1.0
+    assert r.per_scenario_recall["brute_force"] == 1.0
+    assert r.per_scenario_recall["dns_beacon"] == 0.0
+
+
+def test_empty_inputs_do_not_divide_by_zero():
+    r = evaluate_detections([], malicious_entities=[], all_entities=[])
+    assert r.precision == 0.0 and r.recall == 0.0 and r.f1 == 0.0
+    assert r.false_positive_rate == 0.0
+
+
+def test_to_dict_is_jsonb_friendly():
+    anoms = [_anom("bad1", 95)]
+    r = evaluate_detections(anoms, malicious_entities=["bad1"], all_entities=["bad1", "good1"])
+    d = r.to_dict()
+    # keys the experiments UI/compare would chart
+    for k in ("precision", "recall", "f1", "false_positive_rate", "threshold"):
+        assert k in d and isinstance(d[k], float)
+    assert isinstance(d["flagged_entities"], list)

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -2,6 +2,11 @@ FROM jupyter/scipy-notebook:python-3.11
 
 USER root
 
+# ensure modern build tooling so sdist-only deps (e.g. pyspark) can generate
+# metadata in an isolated build env (fixes "setuptools is not available in the
+# build environment" during the data-connector install below)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 # install openuba SDK
 COPY sdk/src/openuba /tmp/openuba-sdk/src/openuba
 COPY sdk/pyproject.toml /tmp/openuba-sdk/

--- a/docs/DATASETS_AND_EVALUATION.md
+++ b/docs/DATASETS_AND_EVALUATION.md
@@ -1,0 +1,110 @@
+# Datasets & Detection Evaluation
+
+This guide covers how test data flows through OpenUBA and how to **evaluate** a
+model's detections against known ground truth — the "Data Ingestion & Testing"
+capability from issue #35.
+
+## Datasets on disk
+
+Raw logs live under `test_datasets/<dataset>/<log_type>/<file>`. OpenUBA ships
+one real capture, `toy_1` (Zeek + Bluecoat: `proxy`, `dns`, `ssh`, `dhcp`).
+
+On startup (local mode) the ingestion service walks every dataset directory and
+fans each log type out into two queryable surfaces:
+
+- a **Spark table** `"<dataset>_<log_type>"` (e.g. `toy_1_proxy`)
+- an **Elasticsearch index** `"openuba-<log_type>-<dataset>"` (e.g. `openuba-proxy-toy_1`)
+
+### Adding another dataset
+
+Drop a second capture in the same layout — for example
+`test_datasets/labeled_1/{proxy,ssh,dns}/…` — and it is ingested automatically;
+no code change is needed. (Previously a whitelist hard-limited ingestion to
+`toy_1`.) Keep per-log-type formats consistent with the parser:
+
+| log types | separator | header | encoding |
+|---|---|---|---|
+| `proxy` / `bluecoat` | space | yes | ISO-8859-1 |
+| `ssh` / `dns` / `dhcp` | tab | no | UTF-8 |
+
+Ingest on demand via the API:
+
+```bash
+curl -X POST "$API/api/v1/data/ingest" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"dataset_name": "labeled_1", "ingest_to_spark": true, "ingest_to_es": true}'
+```
+
+The new tables/indices then appear automatically in the model-run dataset
+picker and on the Data page.
+
+## Ground truth
+
+To *test* detections you need to know which entities are actually malicious. For
+a labeled/benchmark dataset, record its known-bad `entity_id`s (the identity
+column the model carries onto each anomaly — e.g. `cs-username` for proxy, the
+uid/host for ssh/dns). Keep that answer key with the dataset, e.g.
+`test_datasets/labeled_1/ground_truth.json`:
+
+```json
+{
+  "dataset": "labeled_1",
+  "malicious_entities": ["u_exfil_01", "u_brute_01", "h_beacon_01"],
+  "scenarios": {
+    "data_exfil": ["u_exfil_01"],
+    "brute_force": ["u_brute_01"],
+    "dns_beacon": ["h_beacon_01"]
+  }
+}
+```
+
+Ground truth here is the offline benchmark answer key. It complements — it does
+not replace — the live analyst-labeling surface (`UserFeedback`, with
+`feedback_type` = `true_positive` / `false_positive`), which captures dispositions
+on real anomalies in production.
+
+## Evaluating a run
+
+Run a model against a dataset the usual way (via the UI, SDK, or API — see the
+model-run docs), note the resulting `run_id`, then score its detections:
+
+```python
+import openuba
+openuba.configure(api_url="http://localhost:8000", token="<token>")
+
+metrics = openuba.evaluate_run(
+    run_id,
+    malicious_entities=["u_exfil_01", "u_brute_01", "h_beacon_01"],
+    all_entities=[...],          # optional: full population, for FP-rate / TNs
+    threshold=50,                # risk_score at/above which an entity is "flagged"
+    scenarios={...},             # optional: per-scenario recall
+)
+print(metrics["precision"], metrics["recall"], metrics["f1"])
+```
+
+Under the hood this reads the run's anomalies and scores them:
+
+- **Read** — anomalies are fetched scoped to the run:
+  `GET /api/v1/anomalies?run_id=<id>` (also `openuba.query_anomalies(run_id=…)`,
+  or GraphQL `allAnomalies(condition:{runId})`).
+- **Score** — `POST /api/v1/evaluate/run` computes entity-level
+  precision / recall / F1 / false-positive-rate (+ per-scenario recall) with the
+  shared `core.services.detection_eval` scorer.
+
+An entity counts as *flagged* if it has an anomaly whose `risk_score` meets the
+threshold, mirroring how OpenUBA models emit one anomaly per event with a 0–100
+score.
+
+## Tracking results across runs
+
+The returned metrics are JSONB-friendly and are meant to be stored on an
+**experiment run** so you can compare detectors and tunings over time:
+
+```python
+exp = openuba.create_experiment("labeled_1 benchmark")
+openuba.add_experiment_run(exp["id"], model_id=model_id, metrics=metrics)
+openuba.compare_experiment_runs(exp["id"])
+```
+
+This reuses OpenUBA's existing experiments/metrics machinery rather than a
+separate store.

--- a/sdk/src/openuba/__init__.py
+++ b/sdk/src/openuba/__init__.py
@@ -266,12 +266,20 @@ def query_elasticsearch(index, query_body, es_host=None):
 # ─── UBA-Specific Query Methods ─────────────────────────────────────
 
 
-def query_anomalies(entity_id=None, model_id=None, min_risk=None,
+def query_anomalies(entity_id=None, model_id=None, run_id=None, min_risk=None,
                     max_risk=None, limit=1000):
-    """Query anomalies from the platform."""
+    """Query anomalies from the platform (optionally scoped to one run)."""
     return _get_client().query_anomalies(entity_id=entity_id, model_id=model_id,
-                                         min_risk=min_risk, max_risk=max_risk,
-                                         limit=limit)
+                                         run_id=run_id, min_risk=min_risk,
+                                         max_risk=max_risk, limit=limit)
+
+
+def evaluate_run(run_id, malicious_entities, all_entities=None, threshold=50.0,
+                 scenarios=None):
+    """Score a run's detections against ground truth (precision/recall/f1)."""
+    return _get_client().evaluate_run(run_id, malicious_entities,
+                                      all_entities=all_entities,
+                                      threshold=threshold, scenarios=scenarios)
 
 
 def get_entity_risk(entity_id):
@@ -346,6 +354,7 @@ __all__ = [
     "query_elasticsearch",
     # UBA queries
     "query_anomalies",
+    "evaluate_run",
     "get_entity_risk",
     "query_cases",
     "list_rules",

--- a/sdk/src/openuba/client.py
+++ b/sdk/src/openuba/client.py
@@ -623,6 +623,24 @@ class OpenUBAClient:
             params["max_risk_score"] = max_risk
         return self._get("/api/v1/anomalies", params=params)
 
+    def evaluate_run(self, run_id, malicious_entities, all_entities=None,
+                     threshold=50.0, scenarios=None):
+        '''
+        score a model run's detections against a ground-truth set of malicious
+        entities. Returns precision / recall / f1 / false_positive_rate (+ per-
+        scenario recall) — the shape you can store in an experiment run's metrics.
+        '''
+        payload = {
+            "run_id": str(run_id),
+            "malicious_entities": list(malicious_entities),
+            "threshold": threshold,
+        }
+        if all_entities is not None:
+            payload["all_entities"] = list(all_entities)
+        if scenarios is not None:
+            payload["scenarios"] = {k: list(v) for k, v in scenarios.items()}
+        return self._post("/api/v1/evaluate/run", payload)
+
     def get_entity_risk(self, entity_id):
         '''get entity risk profile'''
         return self._get(f"/api/v1/entities/{entity_id}")

--- a/sdk/src/openuba/client.py
+++ b/sdk/src/openuba/client.py
@@ -607,14 +607,16 @@ class OpenUBAClient:
 
     # ─── UBA-Specific Query Methods ─────────────────────────────────
 
-    def query_anomalies(self, entity_id=None, model_id=None, min_risk=None,
-                        max_risk=None, limit=1000):
-        '''query anomalies from the platform'''
+    def query_anomalies(self, entity_id=None, model_id=None, run_id=None,
+                        min_risk=None, max_risk=None, limit=1000):
+        '''query anomalies from the platform (optionally scoped to one run)'''
         params = {"limit": limit}
         if entity_id:
             params["entity_id"] = entity_id
         if model_id:
             params["model_id"] = str(model_id)
+        if run_id:
+            params["run_id"] = str(run_id)
         if min_risk is not None:
             params["min_risk_score"] = min_risk
         if max_risk is not None:

--- a/sdk/tests/test_evaluate.py
+++ b/sdk/tests/test_evaluate.py
@@ -1,0 +1,54 @@
+'''
+Copyright 2019-Present The OpenUBA Platform Authors
+tests for the SDK detection-evaluation surface (issue #35)
+'''
+
+from unittest.mock import patch, MagicMock
+
+from openuba.client import OpenUBAClient
+
+
+class TestEvaluateSDK:
+    def setup_method(self):
+        self.client = OpenUBAClient(api_url="http://test:8000", token="test-token")
+
+    @patch('openuba.client.requests.post')
+    def test_evaluate_run_builds_payload_and_hits_endpoint(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"precision": 1.0, "recall": 0.5, "f1": 0.666667},
+        )
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = self.client.evaluate_run(
+            "run-123", ["bad1", "bad2"],
+            all_entities=["bad1", "bad2", "g1"],
+            threshold=60,
+            scenarios={"exfil": ["bad1"]},
+        )
+
+        assert result["recall"] == 0.5
+        args, kwargs = mock_post.call_args
+        assert args[0].endswith("/api/v1/evaluate/run")
+        body = kwargs["json"]
+        assert body["run_id"] == "run-123"
+        assert body["malicious_entities"] == ["bad1", "bad2"]
+        assert body["threshold"] == 60
+        assert body["all_entities"] == ["bad1", "bad2", "g1"]
+        assert body["scenarios"] == {"exfil": ["bad1"]}
+
+    @patch('openuba.client.requests.post')
+    def test_evaluate_run_minimal_payload(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200, json=lambda: {"recall": 0.0})
+        mock_post.return_value.raise_for_status = MagicMock()
+        self.client.evaluate_run("run-9", ["bad1"])
+        body = mock_post.call_args.kwargs["json"]
+        assert body == {"run_id": "run-9", "malicious_entities": ["bad1"], "threshold": 50.0}
+
+    @patch('openuba.client.requests.get')
+    def test_query_anomalies_scopes_by_run(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"items": []})
+        mock_get.return_value.raise_for_status = MagicMock()
+        self.client.query_anomalies(run_id="run-42")
+        params = mock_get.call_args.kwargs["params"]
+        assert params["run_id"] == "run-42"


### PR DESCRIPTION
Draft / WIP for #35 (Data Ingestion & Testing). Building this on OpenUBA's **existing rails** — deliberately not inventing a parallel workflow.

## Background
#35 asked for sample data + a way to test detections. The thread's real blocker (anupamme): the data has **no labels**, so you can't evaluate whether a model works. This delivers the missing evaluation capability and makes additional datasets first-class.

Design was hardened by auditing the code first, which corrected several early assumptions: models featurize **raw logs** themselves (no pre-aggregation), the canonical run path is **ES/Spark** (not local_csv), ground truth should reuse **`UserFeedback`**, and metrics belong in **`ExperimentRun.metrics`** — so this reuses those instead of rebuilding them.

## Phase A (this PR so far) — all tested

- **Detection scorer** (`core/services/detection_eval.py`): pure, dependency-light entity-level precision/recall/F1/FPR (+ per-scenario recall), shaped for `ExperimentRun.metrics`.
- **Run-scoped anomaly reads**: `AnomalyRepository.list_all(run_id=…)`, a `run_id` param on `GET /api/v1/anomalies`, and `query_anomalies(run_id=)` in the SDK (the read evaluation needs).
- **Evaluation endpoint + SDK**: `POST /api/v1/evaluate/run` (reads a run's anomalies, scores them) and `openuba.evaluate_run(run_id, malicious_entities, …)`.
- **Ingest any dataset**: replaced the hard `toy_1`-only whitelist in `ingest_all_datasets` with a "looks like a dataset" check — additional captures under `test_datasets/` now fan out to their Spark tables + ES indices with no code change (toy_1 unchanged).
- **Docs**: `docs/DATASETS_AND_EVALUATION.md`.

### Tests (18, green locally; run in CI)
- unit (no infra): 10 scorer + 2 dataset-scan
- API/repo (testcontainers Postgres): 2 evaluation endpoint + 1 run_id filter
- SDK: 3

## Phase B (follow-up in this branch)
- A small **real-format labeled capture** under `test_datasets/` with injected known-bad entities + a `ground_truth.json`.
- **Seed `Dataset` rows** (none are seeded today) so shipped datasets show on `/datasets`.
- An **e2e test**: ingest → train/infer via ES → read anomalies by run → evaluate → assert recall on known-bad entities ≥ bar; extend the JIT matrix.
- A starter **notebook** (extends `09_model_pipeline.ipynb` with an eval cell) and a CLI `dataset` group.

Also fixes two real bugs found while mapping: `jobs.py` local_csv missing `file_name`, and the dead `source_group` `LocalPandasLoader` import (to be addressed in Phase B).

Closes #35